### PR TITLE
Add a snapcraft build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 * travis: [![Build
 Status](https://travis-ci.org/robotlinker/robotlinker_core.svg?branch=master)](https://travis-ci.org/robotlinker/robotlinker_core)
+* snap: [![Snap Status](https://build.snapcraft.io/badge/robotlinker/robotlinker_core.svg)](https://build.snapcraft.io/user/robotlinker/robotlinker_core)
 
 ## Prerequisite
 ### UR Simulator


### PR DESCRIPTION
Congrats on the robotlinker-core snap. Here's a badge to show the current snap build status.